### PR TITLE
Set sshCommandStream call to goroutine

### DIFF
--- a/session.go
+++ b/session.go
@@ -198,10 +198,10 @@ func worker(hosts <-chan string, results chan<- Result, config *Config, resChan 
 				for i := range *cfg.JobStack {
 					j := (*cfg.JobStack)[i]
 					cfg.Job = &j
-					sshCommandStream(host, &cfg, resChan)
+					go sshCommandStream(host, &cfg, resChan)
 				}
 			} else {
-				sshCommandStream(host, config, resChan)
+				go sshCommandStream(host, config, resChan)
 			}
 		}
 	}


### PR DESCRIPTION
Updated call to sshCommandStream as it was hanging on non-existent hosts as it waited for SSH dial to timeout.