### PR TITLE
Track slow hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+26/12/2021
+- Added slow host detection. This change BREAKS any call to Config.Stream() in previous versions, as the Result value is now accepted as a pointer.
+
 29/09/2021
 - Minor error and comment updates.
 

--- a/_examples/slow_hosts/main.go
+++ b/_examples/slow_hosts/main.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"fmt"
+	"github.com/discoriver/massh"
+	"golang.org/x/crypto/ssh"
+	"sync"
+	"time"
+)
+
+func main() {
+	// Job to generate not output on StdOut for 5 seconds and cause a slow trigger.
+	j := &massh.Job{
+		Command: "echo \"Hello, World\"; sleep 5",
+	}
+
+	sshc := &ssh.ClientConfig{
+		// Fake credentials
+		User:            "u01",
+		Auth:            []ssh.AuthMethod{ssh.Password("password")},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         time.Duration(2) * time.Second,
+	}
+
+	cfg := massh.NewConfig()
+	cfg.SSHConfig = sshc
+	cfg.Job = j
+	cfg.WorkerPool = 10
+	cfg.SetHosts([]string{"192.168.1.118"})
+
+	// Should be slow, bump to 6 if not.
+	cfg.SlowTimeout = 5
+
+	resChan := make(chan *massh.Result)
+
+	// This should be the last responsibility from the massh package. Handling the Result channel is up to the user.
+	err := cfg.Stream(resChan)
+	if err != nil {
+		panic(err)
+	}
+
+	var wg sync.WaitGroup
+	// This can probably be cleaner. We're hindered somewhat, I think, by reading a channel from a channel.
+	for {
+		select {
+		case result := <-resChan:
+			wg.Add(1)
+			go func() {
+				// Need to handle any errors as the existence of this value indicates that the ssh task wasn't started
+				// due to some functional error.
+				//
+				// The reason for this design is that it was important to me not to have the cfg.Stream function return
+				// anything, and having it as part of the Result means we can more easily associate the error with a
+				// host.
+				if result.Error != nil {
+					fmt.Printf("%s: %s\n", result.Host, result.Error)
+					wg.Done()
+				} else {
+					readStream(result, &wg)
+				}
+			}()
+		default:
+			if massh.NumberOfStreamingHostsCompleted == len(cfg.Hosts) {
+				// We want to wait for all goroutines to complete before we declare that the work is finished, as
+				// it's possible for us to execute this code before the gofunc above has completed if left unchecked.
+				wg.Wait()
+
+				// This should always be the last thing written. Waiting above ensures this.
+				return
+			}
+		}
+	}
+}
+
+// Read Stdout stream
+func readStream(res *massh.Result, wg *sync.WaitGroup) error {
+	for {
+		select {
+		case d := <-res.StdOutStream:
+			fmt.Printf("%s: %s", res.Host, d)
+		case <-res.DoneChannel:
+			// Confirm that the host has exited.
+			if res.IsSlow == true {
+				fmt.Printf("%s completed, and was slow.\n", res.Host)
+			} else {
+				fmt.Printf("%s completed, and was not slow.\n", res.Host)
+			}
+			wg.Done()
+		}
+	}
+}

--- a/config.go
+++ b/config.go
@@ -27,7 +27,7 @@ type Config struct {
 
 	// Stream-only
 	SlowTimeout     int  // Timeout for delcaring that a host is slow.
-	CancelSlowHosts bool // Automatically cancel hosts that are flagged as slow.
+	CancelSlowHosts bool // Not implemented. Automatically cancel hosts that are flagged as slow.
 }
 
 // NewConfig initialises a new massh.Config.
@@ -40,12 +40,14 @@ func NewConfig() *Config {
 	return c
 }
 
+// SetSlowTimeout sets the SlowTimeout value for config.
 func (c *Config) SetSlowTimeout(timeout int) {
 	c.SlowTimeout = timeout
 }
 
-func (c *Config) AutoCancelSlowHosts(cancel bool) {
-	c.CancelSlowHosts = cancel
+// AutoCancelSlowHosts will cancel/terminate slow host sessions.
+func (c *Config) AutoCancelSlowHosts() {
+	c.CancelSlowHosts = true
 }
 
 // SetHosts adds a slice of strings as hosts to config. Removes duplicates.
@@ -98,9 +100,9 @@ func (c *Config) SetSSHHostKeyCallback(callback ssh.HostKeyCallback) {
 	c.SSHConfig.HostKeyCallback = callback
 }
 
-// Run executes the config, return a slice of Results once the command has exited.
+// Run executes the config, return a slice of Results once the command has exited on all hosts.
 //
-// This is a rudimentary function, and is not affected by SlowTimeout or CancelSlowHosts. By extension, the Results returned using Run always have an IsSlow value of false.
+// This is a rudimentary function, and is not affected by Config.SlowTimeout or Config.CancelSlowHosts. By extension, the Results returned using Run always have an IsSlow value of false.
 func (c *Config) Run() ([]Result, error) {
 	if err := checkJobs(c); err != nil {
 		return nil, err

--- a/script.go
+++ b/script.go
@@ -27,7 +27,7 @@ type shell struct {
 
 type python struct {
 	bytes []byte
-	args string
+	args  string
 
 	commandString string
 
@@ -51,7 +51,7 @@ func newScript(scriptFile string, args ...string) (script, error) {
 	if strings.HasSuffix(scriptFile, ".sh") {
 		shellScript := &shell{
 			bytes: scriptBytes,
-			args: strings.Join(args, " "),
+			args:  strings.Join(args, " "),
 		}
 		return shellScript, nil
 	}
@@ -59,7 +59,7 @@ func newScript(scriptFile string, args ...string) (script, error) {
 	if strings.HasSuffix(scriptFile, ".py") {
 		pythonScript := &python{
 			bytes: scriptBytes,
-			args: strings.Join(args, " "),
+			args:  strings.Join(args, " "),
 		}
 		return pythonScript, nil
 	}

--- a/session.go
+++ b/session.go
@@ -187,7 +187,7 @@ func readToBytesChannel(reader io.Reader, stream chan []byte, r *Result, slowTim
 
 	rdr := bufio.NewReader(reader)
 	for {
-		line, err := rdr.ReadBytes('\n')
+		line, err := rdr.ReadBytes('\n') // ReadBytes will wait until new line character is read.
 		t.Reset(slowTimeoutDuration)
 		if err != nil {
 			if err == io.EOF {

--- a/session_test.go
+++ b/session_test.go
@@ -133,7 +133,7 @@ func TestSshCommandStreamWithSlowHost(t *testing.T) {
 
 					wg.Done()
 				} else {
-					readStream(result, &wg, t)
+					readStreamSlow(result, &wg, t)
 				}
 			}()
 		default:
@@ -198,8 +198,18 @@ func TestSshCommandStreamBigData(t *testing.T) {
 		}
 	}
 }
-
 func readStream(res *Result, wg *sync.WaitGroup, t *testing.T) {
+	for {
+		select {
+		case d := <-res.StdOutStream:
+			fmt.Print(string(d))
+		case <-res.DoneChannel:
+			wg.Done()
+		}
+	}
+}
+
+func readStreamSlow(res *Result, wg *sync.WaitGroup, t *testing.T) {
 	for {
 		select {
 		case d := <-res.StdOutStream:

--- a/ssh.go
+++ b/ssh.go
@@ -78,7 +78,7 @@ func generateSSHClientWithPotentialBastion(host string, config *Config) (*ssh.Cl
 	return client, nil
 }
 
-// runJob is ssh.Session.Run, with an activity timeout
+// runJob is ssh.Session.Run
 func runJob(session *ssh.Session, job string) error {
 	if err := session.Run(job); err != nil {
 		return err

--- a/ssh.go
+++ b/ssh.go
@@ -78,7 +78,7 @@ func generateSSHClientWithPotentialBastion(host string, config *Config) (*ssh.Cl
 	return client, nil
 }
 
-// runJob is ssh.Session.Run
+// runJob is ssh.Session.Run, with an activity timeout
 func runJob(session *ssh.Session, job string) error {
 	if err := session.Run(job); err != nil {
 		return err


### PR DESCRIPTION
### What feature/change has been implemented?

- Implemented slow host tracking for streaming. Slow hosts can now be identified by checking the `Result.IsSlow` value, but should be noted that it is subject to change until `Result.DoneChannel` has been written.

### What impact does this have on the existing API?

- The `Config.Stream()` method needed to be updated to accept a channel of `Result` pointers. This breaks previous versions. 

### What issues (if any) does this fix?

- None.